### PR TITLE
Fixing margins on list of figures/tables and vita pages

### DIFF
--- a/uclathes.cls
+++ b/uclathes.cls
@@ -474,7 +474,7 @@
   \if@figures\chapter*{List of Figures\markboth
    {LIST OF FIGURES}{LIST OF FIGURES}}\@starttoc{lof}\fi}
 
-\def\l@figure{\@dottedtocline{1}{1.5em}{2.3em}}
+\def\l@figure{\@dottedtocline{1}{0em}{2.3em}}
 
 % LIST OF TABLES
 %

--- a/uclathti.clo
+++ b/uclathti.clo
@@ -258,7 +258,7 @@
 
 \newcounter{vitaitems}
 \setcounter{vitaitems}{0}
-\newcommand\@vitadate[1]{{\parbox[t]{1.25in}{\normalfont{#1}}}}
+\newcommand\@vitadate[1]{{\parbox[t]{1in}{\normalfont{#1}}}}
 \newcommand\@vitatext[1]{{\parbox[t]{5.25in}{\normalfont{#1}}}}
 \newcommand\vitaitem[2]{
    \ifcase\value{vitaitems}
@@ -340,7 +340,7 @@
 
 \newcommand\@printvitaitem[1]{
    \noindent
-   \begin {tabular} {@{}p{1.25in}@{}p{5.25in}@{}}
+   \begin {tabular} {@{}p{1in}@{}p{6in}@{}}
       #1
    \end {tabular}
 }


### PR DESCRIPTION
The person that reported this matter chose not to share the solution or issue a pull request, so I fixed it. List of Figures, List of Tables and Vita all have 1in margins now. Some analysts don't check this apparently as mine was approved.