### PR TITLE
Add paper size specification

### DIFF
--- a/uclath17.clo
+++ b/uclath17.clo
@@ -103,6 +103,11 @@
 % and they matched.   -johnh, 20-Jun-95
 %
 
+% PAPER SIZE
+% This ensures that the page size is 8.5 x 11 inches even if using a European TeX distribution (such as Overleaf)
+\paperheight 11in
+\paperwidth 8.5in
+
 % SIDE MARGINS:
 %\oddsidemargin 0.65in     %   Note that \oddsidemargin = \evensidemargin
 %\evensidemargin 0.65in    % these are added to the 1 inch margin.


### PR DESCRIPTION
Because some platforms (such as Overleaf) use A4 paper size by default, I added commands to make the \paperheight 11in and \paperwidth 8.5in.  Obviously, the wrong paper size will mess up the margin and page number positions according to the UCLA requirements!